### PR TITLE
AreaText - it is possible to jump with cursor by focusing

### DIFF
--- a/apptools/apptools.go
+++ b/apptools/apptools.go
@@ -62,8 +62,8 @@ func (t *Tools) Focus(component tview.Primitive) {
 	switch component := component.(type) {
 	case *tview.TextArea:
 		if hasFocus {
-			_, _, x, y := component.GetCursor()
-			if x == 0 && y == 0 {
+			_, _, toRow, toColumn := component.GetCursor()
+			if toRow == 0 && toColumn == 0 {
 				component.SetText(component.GetText(), true)
 			} else {
 				component.SetText(component.GetText(), false)

--- a/apptools/apptools.go
+++ b/apptools/apptools.go
@@ -58,6 +58,18 @@ func (t *Tools) ShowPage(pageName configuration.PageName) {
 }
 
 func (t *Tools) Focus(component tview.Primitive) {
+	hasFocus := component.HasFocus()
+	switch component := component.(type) {
+	case *tview.TextArea:
+		if hasFocus {
+			_, _, x, y := component.GetCursor()
+			if x == 0 && y == 0 {
+				component.SetText(component.GetText(), true)
+			} else {
+				component.SetText(component.GetText(), false)
+			}
+		}
+	}
 	t.app.SetFocus(component)
 }
 


### PR DESCRIPTION
I realized Ctrl+N does something else already, returns the initial snippet data.
However, added new functionality: Now by refocusing the TextArea with shortcut keys, it is possible to move cursor to beginning or end

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved focus handling for text inputs: when a text area already has focus the caret position and content are preserved to avoid unexpected resets when refocusing, resulting in more stable and predictable text editing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->