### PR TITLE
Add language dropdown to search and all snippets page

### DIFF
--- a/pages/allsnippetspage/allsnippetspage.go
+++ b/pages/allsnippetspage/allsnippetspage.go
@@ -15,6 +15,7 @@ type AllSnippetsPage struct {
 	title                  *tview.TextArea
 	description            *tview.TextArea
 	urls                   *tview.TextArea
+	language               *tview.DropDown
 	table                  *tview.Table
 	tools                  *apptools.Tools
 	logs                   *widgets.LogsWidget

--- a/pages/allsnippetspage/initialization.go
+++ b/pages/allsnippetspage/initialization.go
@@ -1,11 +1,13 @@
 package allsnippetspage
 
 import (
+	"slices"
 	"strconv"
 
 	"github.com/gdamore/tcell/v2"
 	"github.com/gwkeit/apptools"
 	"github.com/gwkeit/configuration"
+	"github.com/gwkeit/slicelib"
 	"github.com/gwkeit/uibuilder"
 	"github.com/rivo/tview"
 )
@@ -106,6 +108,15 @@ func (asp *AllSnippetsPage) initTable() {
 		asp.title.SetText(snippet.Title, false)
 		asp.description.SetText(snippet.Description, false)
 		asp.urls.SetText(snippet.Url, false)
+		if snippet.Language.Valid {
+			idx := slices.Index(configuration.LanguagesStrings, snippet.Language.String)
+			if idx < 0 {
+				idx = 0
+			}
+			asp.language.SetCurrentOption(idx + 1)
+		} else {
+			asp.language.SetCurrentOption(1)
+		}
 	}).
 		SetBlurFunc(func() {
 			asp.table.SetSelectable(false, false)
@@ -113,10 +124,16 @@ func (asp *AllSnippetsPage) initTable() {
 }
 
 func (asp *AllSnippetsPage) initSnippetDataFlex() *tview.Flex {
+	asp.language = uibuilder.NewDropDown(asp.themeName, "")
+	asp.language.SetOptions(slicelib.Concat([]string{""}, configuration.LanguagesStrings), nil)
+	asp.language.SetCurrentOption(0)
+	asp.language.SetDisabled(true)
+
 	return tview.NewFlex().SetDirection(tview.FlexRow).
 		AddItem(uibuilder.NewWidget(asp.themeName, "Title:", asp.title), 0, 1, false).
 		AddItem(uibuilder.NewWidget(asp.themeName, "Description:", asp.description), 0, 3, false).
-		AddItem(uibuilder.NewWidget(asp.themeName, "URLs:", asp.urls), 0, 3, false)
+		AddItem(uibuilder.NewWidget(asp.themeName, "URLs:", asp.urls), 0, 2, false).
+		AddItem(uibuilder.NewWidget(asp.themeName, "Language:", asp.language), 3, 1, false)
 }
 
 func (asp *AllSnippetsPage) initInputCapture() {

--- a/pages/allsnippetspage/initialization.go
+++ b/pages/allsnippetspage/initialization.go
@@ -110,12 +110,9 @@ func (asp *AllSnippetsPage) initTable() {
 		asp.urls.SetText(snippet.Url, false)
 		if snippet.Language.Valid {
 			idx := slices.Index(configuration.LanguagesStrings, snippet.Language.String)
-			if idx < 0 {
-				idx = 0
-			}
 			asp.language.SetCurrentOption(idx + 1)
 		} else {
-			asp.language.SetCurrentOption(1)
+			asp.language.SetCurrentOption(0)
 		}
 	}).
 		SetBlurFunc(func() {

--- a/pages/searchpage/initialization.go
+++ b/pages/searchpage/initialization.go
@@ -36,6 +36,10 @@ func (sp *SearchPage) initMetadataFields() {
 
 	sp.urls = uibuilder.NewTextArea(sp.themeName, "", "")
 	sp.urls.SetDisabled(true)
+
+	sp.language = uibuilder.NewDropDown(sp.themeName, "")
+	sp.language.SetOptions(slices.Concat([]string{""}, configuration.LanguagesStrings), nil)
+	sp.language.SetDisabled(true)
 }
 
 func (sp *SearchPage) initBody() {
@@ -117,6 +121,16 @@ func (sp *SearchPage) initResultList() {
 			sp.body.SetText(snippet.Body, true)
 			sp.description.SetText(snippet.Description, true)
 			sp.urls.SetText(snippet.Url, true)
+
+			if snippet.Language.Valid {
+				idx := slices.Index(configuration.LanguagesStrings, snippet.Language.String)
+				if idx < 0 {
+					idx = 0
+				}
+				sp.language.SetCurrentOption(idx + 1)
+			} else {
+				sp.language.SetCurrentOption(1)
+			}
 		})
 	sp.totalFoundView = uibuilder.NewTextView(sp.themeName, strconv.FormatInt(sp.totalFoundAmount, 10))
 	sp.currentPageView = uibuilder.NewTextView(sp.themeName, strconv.FormatInt(sp.currentPage, 10))
@@ -142,7 +156,8 @@ func (sp *SearchPage) initGridLayout() {
 	metadataFlex := tview.NewFlex().SetDirection(tview.FlexRow).
 		AddItem(uibuilder.NewWidget(sp.themeName, "Title:", sp.title), 3, 1, false).
 		AddItem(uibuilder.NewWidget(sp.themeName, "Description:", sp.description), 0, 3, false).
-		AddItem(uibuilder.NewWidget(sp.themeName, "URLs:", sp.urls), 0, 3, false)
+		AddItem(uibuilder.NewWidget(sp.themeName, "URLs:", sp.urls), 0, 2, false).
+		AddItem(uibuilder.NewWidget(sp.themeName, "Language:", sp.language), 3, 1, false)
 
 	sp.grid.AddItem(uibuilder.NewWidget(sp.themeName, "Code:", sp.body), 2, 0, 1, 1, 0, 100, false).
 		AddItem(metadataFlex, 2, 1, 1, 1, 0, 100, false)

--- a/pages/searchpage/initialization.go
+++ b/pages/searchpage/initialization.go
@@ -124,12 +124,9 @@ func (sp *SearchPage) initResultList() {
 
 			if snippet.Language.Valid {
 				idx := slices.Index(configuration.LanguagesStrings, snippet.Language.String)
-				if idx < 0 {
-					idx = 0
-				}
 				sp.language.SetCurrentOption(idx + 1)
 			} else {
-				sp.language.SetCurrentOption(1)
+				sp.language.SetCurrentOption(0)
 			}
 		})
 	sp.totalFoundView = uibuilder.NewTextView(sp.themeName, strconv.FormatInt(sp.totalFoundAmount, 10))

--- a/pages/searchpage/searchpage.go
+++ b/pages/searchpage/searchpage.go
@@ -22,6 +22,7 @@ type SearchPage struct {
 	resultList        *tview.List
 	description       *tview.TextArea
 	urls              *tview.TextArea
+	language          *tview.DropDown
 	title             *tview.TextArea
 	grid              *tview.Grid
 	Frame             *tview.Frame

--- a/uibuilder/uibuilder.go
+++ b/uibuilder/uibuilder.go
@@ -97,6 +97,8 @@ func NewDropDown(themeName AppThemeName, title string) *tview.DropDown {
 		).
 		SetBackgroundColor(tcell.ColorDefault)
 
+	dropDown.SetDisabledStyle(generateFieldStyle(theme))
+
 	return dropDown
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added language selection dropdowns to snippet details on All Snippets and Search pages, showing the language of the currently selected snippet (defaulted when unspecified).

* **UI Improvements**
  * Dropdowns are initially disabled and styled consistently with other disabled fields.
  * Metadata layout updated to allocate space for the new Language field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->