### PR TITLE
Rework snippet select for search and all snippets page

### DIFF
--- a/pages/allsnippetspage/initialization.go
+++ b/pages/allsnippetspage/initialization.go
@@ -101,6 +101,7 @@ func (asp *AllSnippetsPage) initTable() {
 	asp.table = uibuilder.NewTable(asp.themeName, 1, 1)
 	asp.table.SetSelectionChangedFunc(func(row, column int) {
 		if row == 0 {
+			asp.selectedSnippetId = -1
 			asp.clearMetadataFields()
 			return
 		}

--- a/pages/allsnippetspage/initialization.go
+++ b/pages/allsnippetspage/initialization.go
@@ -16,7 +16,7 @@ var shortcutDescription = []apptools.ShortcutDescription{
 	{"ctrl+P", "Focus page number field"},
 	{"ctrl+I", "Focus page size field"},
 	{"ctrl+T", "Focus table"},
-	{"ctrl+E", "Edit selected snippet"},
+	{"ctrl+E/Enter", "Edit selected snippet"},
 	{"}", "Show next table page"},
 	{"{", "Show previous table page"},
 }
@@ -99,8 +99,9 @@ func (asp *AllSnippetsPage) initFrame() {
 
 func (asp *AllSnippetsPage) initTable() {
 	asp.table = uibuilder.NewTable(asp.themeName, 1, 1)
-	asp.table.SetSelectedFunc(func(row int, column int) {
+	asp.table.SetSelectionChangedFunc(func(row, column int) {
 		if row == 0 {
+			asp.clearMetadataFields()
 			return
 		}
 		snippet := asp.tools.Repo.FindSnippet(asp.tools.Ctx, asp.snippets[row-1].ID)
@@ -113,6 +114,13 @@ func (asp *AllSnippetsPage) initTable() {
 			asp.language.SetCurrentOption(idx + 1)
 		} else {
 			asp.language.SetCurrentOption(0)
+		}
+	})
+	asp.table.SetSelectedFunc(func(row int, column int) {
+		if asp.selectedSnippetId > -1 {
+			asp.tools.GoToPage(configuration.EditPage, asp.selectedSnippetId)
+		} else {
+			asp.logs.AddErrorLogs([]string{"No snippet selected."})
 		}
 	}).
 		SetBlurFunc(func() {

--- a/pages/allsnippetspage/private.go
+++ b/pages/allsnippetspage/private.go
@@ -74,6 +74,7 @@ func (asp *AllSnippetsPage) clearMetadataFields() {
 	asp.description.SetText("", false)
 	asp.title.SetText("", false)
 	asp.urls.SetText("", false)
+	asp.language.SetCurrentOption(0)
 }
 
 func (asp *AllSnippetsPage) focusTable() {

--- a/pages/allsnippetspage/public.go
+++ b/pages/allsnippetspage/public.go
@@ -6,5 +6,4 @@ func (asp *AllSnippetsPage) SwitchToPage() {
 	asp.tools.SwitchToPage(configuration.AllSnippetsPage)
 	asp.populateTable(asp.tools.Ctx)
 	asp.focusTable()
-	asp.clearMetadataFields()
 }

--- a/pages/searchpage/initialization.go
+++ b/pages/searchpage/initialization.go
@@ -59,6 +59,11 @@ func (sp *SearchPage) initSearchField() {
 			sp.foundSnippets = []gwkeitdb.Snippet{}
 		}
 
+		if len(sp.foundSnippets) == 0 {
+			sp.selectedSnippetId = -1
+			sp.clearMetadataFields()
+		}
+
 		sp.totalFoundAmount = int64(len(sp.foundSnippets))
 		sp.totalFoundView.SetText(strconv.FormatInt(sp.totalFoundAmount, 10))
 		sp.setResultListPage(1)
@@ -70,15 +75,10 @@ func (sp *SearchPage) initSearchField() {
 			return unicode.IsLetter(keyCode) || unicode.IsDigit(keyCode) || unicode.IsSpace(keyCode)
 		}).
 		SetDoneFunc(func(key tcell.Key) {
-			if sp.resultList.GetItemCount() == 0 {
-				return
+			if sp.resultList.GetItemCount() > 0 {
+				sp.tools.Focus(sp.resultList)
 			}
 
-			sp.tools.Focus(sp.resultList)
-			index := sp.resultList.GetCurrentItem()
-			onSelect := sp.resultList.GetSelectedFunc()
-			mainText, secText := sp.resultList.GetItemText(index)
-			onSelect(index, mainText, secText, shortcutRunes[index])
 		}).
 		SetChangedFunc(executeSearch)
 
@@ -107,7 +107,7 @@ func (sp *SearchPage) initSearchField() {
 func (sp *SearchPage) initResultList() {
 	sp.resultList = uibuilder.NewList(sp.themeName).
 		ShowSecondaryText(false).
-		SetSelectedFunc(func(index int, mainText string, secondaryText string, shortcut rune) {
+		SetChangedFunc(func(index int, mainText string, secondaryText string, shortcut rune) {
 			id, err := strconv.ParseInt(secondaryText, 10, 64)
 			sp.selectedSnippetId = id
 
@@ -186,11 +186,7 @@ func (sp *SearchPage) initInputCapture() {
 			}
 			resultEvent = nil
 		case tcell.KeyCtrlE:
-			if sp.selectedSnippetId > -1 {
-				sp.tools.GoToPage(configuration.EditPage, sp.selectedSnippetId)
-			} else {
-				sp.logs.AddErrorLogs([]string{"No snippet selected."})
-			}
+			sp.goToEditPage()
 			resultEvent = nil
 		case tcell.KeyCtrlO:
 			sp.tools.Focus(sp.searchType)
@@ -203,6 +199,10 @@ func (sp *SearchPage) initInputCapture() {
 		}
 		if event.Rune() == '{' {
 			sp.showPreviousResultPage()
+			resultEvent = nil
+		}
+		if event.Key() == tcell.KeyEnter && sp.resultList.HasFocus() {
+			sp.goToEditPage()
 			resultEvent = nil
 		}
 

--- a/pages/searchpage/initialization.go
+++ b/pages/searchpage/initialization.go
@@ -22,7 +22,7 @@ var shortcutDescription = []apptools.ShortcutDescription{
 	{Key: "ctrl+L", Description: "Focus result list"},
 	{Key: "ctrl+O", Description: "Focus search type"},
 	{Key: "ctrl+C", Description: "Copy body"},
-	{Key: "ctrl+E", Description: "Edit snippet"},
+	{Key: "ctrl+E/Enter", Description: "Edit snippet"},
 	{"}", "Show next result page"},
 	{"{", "Show previous result page"},
 }

--- a/pages/searchpage/initialization.go
+++ b/pages/searchpage/initialization.go
@@ -109,11 +109,10 @@ func (sp *SearchPage) initResultList() {
 		ShowSecondaryText(false).
 		SetChangedFunc(func(index int, mainText string, secondaryText string, shortcut rune) {
 			id, err := strconv.ParseInt(secondaryText, 10, 64)
-			sp.selectedSnippetId = id
-
 			if err != nil {
 				panic(err)
 			}
+			sp.selectedSnippetId = id
 
 			snippet := sp.tools.Repo.FindSnippet(sp.tools.Ctx, id)
 

--- a/pages/searchpage/private.go
+++ b/pages/searchpage/private.go
@@ -3,6 +3,7 @@ package searchpage
 import (
 	"strconv"
 
+	"github.com/gwkeit/configuration"
 	"github.com/gwkeit/slicelib"
 	"github.com/gwkeit/utils"
 )
@@ -61,5 +62,25 @@ Move to the previous result page if there is such.
 func (sp *SearchPage) showPreviousResultPage() {
 	if sp.currentPage > 1 {
 		sp.setResultListPage(sp.currentPage - 1)
+	}
+}
+
+// clearMetadataFields
+/**
+Clears the metadata fields.
+*/
+func (sp *SearchPage) clearMetadataFields() {
+	sp.title.SetText("", true)
+	sp.body.SetText("", true)
+	sp.description.SetText("", true)
+	sp.urls.SetText("", true)
+	sp.language.SetCurrentOption(0)
+}
+
+func (sp *SearchPage) goToEditPage() {
+	if sp.selectedSnippetId > -1 {
+		sp.tools.GoToPage(configuration.EditPage, sp.selectedSnippetId)
+	} else {
+		sp.logs.AddErrorLogs([]string{"No snippet selected."})
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ctrl+E and Enter now both trigger opening the editor for a selected snippet (search results and lists).

* **Bug Fixes**
  * Metadata fields are cleared when there are no search results or no selection; switching to All Snippets no longer clears metadata.
  * Language selector now resets when metadata is cleared.

* **Refactor**
  * Selection handling revised so metadata updates on selection changes for more consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->