### PR TITLE
Add SQLite and PostgreSQL language options

### DIFF
--- a/configuration/languages.go
+++ b/configuration/languages.go
@@ -3,14 +3,25 @@ package configuration
 type Language string
 
 const (
-	Kotlin     Language = "Kotlin"
-	Python     Language = "Python"
-	TypeScript Language = "TypeScript"
-	Ruby       Language = "Ruby"
-	Go         Language = "Go"
 	Text       Language = "Text"
+	Go         Language = "Go"
+	Kotlin     Language = "Kotlin"
+	PostgreSQL Language = "PostgreSQL"
+	Python     Language = "Python"
+	Ruby       Language = "Ruby"
+	SQLite     Language = "SQLite"
+	TypeScript Language = "TypeScript"
 )
 
-var LanguagesStrings = []string{Text.String(), Go.String(), Kotlin.String(), Python.String(), Ruby.String(), TypeScript.String()}
+var LanguagesStrings = []string{
+	Text.String(),
+	Go.String(),
+	Kotlin.String(),
+	PostgreSQL.String(),
+	Python.String(),
+	Ruby.String(),
+	SQLite.String(),
+	TypeScript.String(),
+}
 
 func (l Language) String() string { return string(l) }

--- a/langdetector/kotlin.go
+++ b/langdetector/kotlin.go
@@ -53,6 +53,7 @@ func IsKotlin(src string) bool {
 	reRejectRuby := regexp.MustCompile(`^\s*(end|elsif|unless|begin|rescue)\b|@` + ident + `\s*=|(^|[\s\(\[\{,]):` + ident + `\b`)
 	reRejectGo := regexp.MustCompile(`^\s*func\b|:=`)
 	reRejectJS := regexp.MustCompile(`^\s*function\b`)
+	reRejectSQL := regexp.MustCompile(`(?i)^\s*(SELECT|INSERT\s+INTO|UPDATE\s+\S+\s+SET|DELETE\s+FROM|CREATE\s+(TABLE|INDEX|VIEW|TRIGGER|SEQUENCE|SCHEMA|EXTENSION|FUNCTION|PROCEDURE|TYPE)|ALTER\s+(TABLE|SEQUENCE)|DROP\s+(TABLE|INDEX|VIEW|FUNCTION|SEQUENCE|SCHEMA|EXTENSION)|PRAGMA|ATTACH|DETACH|VACUUM|REINDEX|EXPLAIN|GRANT|REVOKE|COPY|SHOW|SAVEPOINT)\b`)
 
 	// naive single-line string removal for bracket counting
 	reSingleQuoted := regexp.MustCompile(`'(?:\\.|[^'\\])*'`)
@@ -88,7 +89,11 @@ func IsKotlin(src string) bool {
 		if idx := strings.Index(rejectLine, "//"); idx >= 0 {
 			rejectLine = rejectLine[:idx]
 		}
-		if reRejectJS.MatchString(rejectLine) || reRejectGo.MatchString(rejectLine) || reRejectPython.MatchString(rejectLine) || reRejectRuby.MatchString(rejectLine) {
+		if reRejectJS.MatchString(rejectLine) ||
+			reRejectGo.MatchString(rejectLine) ||
+			reRejectPython.MatchString(rejectLine) ||
+			reRejectRuby.MatchString(rejectLine) ||
+			reRejectSQL.MatchString(rejectLine) {
 			return false
 		}
 

--- a/langdetector/kotlin_test.go
+++ b/langdetector/kotlin_test.go
@@ -30,4 +30,12 @@ func Test_IsKotlin(t *testing.T) {
 		src := "if query is None or query.strip() == \"\":\nif save_query_name is not None and save_query_name.strip() != \"\":\nprint(\n\"You have provided the query name for saving, but query argument is empty!\"\n)\nreturn"
 		assert.False(t, IsKotlin(src))
 	})
+	t.Run("should return false for SELECT specific columns  statement", func(t *testing.T) {
+		src := "SELECT name, surname FROM users"
+		assert.False(t, IsKotlin(src))
+	})
+	t.Run("should return false for SELECT everything statement", func(t *testing.T) {
+		src := "SELECT * FROM users"
+		assert.False(t, IsKotlin(src))
+	})
 }

--- a/langdetector/langdetector.go
+++ b/langdetector/langdetector.go
@@ -1,6 +1,7 @@
 package langdetector
 
 import (
+	"slices"
 	"strings"
 
 	"github.com/gwkeit/configuration"
@@ -27,9 +28,21 @@ func Detect(text string) configuration.Language {
 	if IsTypeScript(text) {
 		detectedLanguages = append(detectedLanguages, configuration.TypeScript)
 	}
+	if IsSQLite(text) {
+		detectedLanguages = append(detectedLanguages, configuration.SQLite)
+	}
+	if IsPostgreSQL(text) {
+		detectedLanguages = append(detectedLanguages, configuration.PostgreSQL)
+	}
 
 	if len(detectedLanguages) == 1 {
 		return detectedLanguages[0]
+	}
+
+	if len(detectedLanguages) == 2 &&
+		slices.Contains(detectedLanguages, configuration.SQLite) &&
+		slices.Contains(detectedLanguages, configuration.PostgreSQL) {
+		return configuration.PostgreSQL
 	}
 
 	return configuration.Text

--- a/langdetector/postgresql.go
+++ b/langdetector/postgresql.go
@@ -71,7 +71,7 @@ func IsPostgreSQL(src string) bool {
 
 	// SQLite-specific rejects
 	reRejectSQLite := regexp.MustCompile(`(?i)\b(AUTOINCREMENT|WITHOUT\s+ROWID)\b`)
-	reRejectSQLiteStmt := regexp.MustCompile(`(?i)^\s*(PRAGMA|ATTACH|DETACH|REINDEX)\b`)
+	reRejectSQLiteStmt := regexp.MustCompile(`(?i)^\s*(PRAGMA|ATTACH|DETACH)\b`)
 
 	anyNonBlank := false
 	inBlockComment := false

--- a/langdetector/postgresql.go
+++ b/langdetector/postgresql.go
@@ -1,0 +1,169 @@
+package langdetector
+
+import (
+	"regexp"
+	"strings"
+)
+
+func IsPostgreSQL(src string) bool {
+	src = strings.ReplaceAll(src, "\r\n", "\n")
+	src = strings.ReplaceAll(src, "\r", "\n")
+
+	lines := strings.Split(src, "\n")
+
+	ident := `[A-Za-z_][A-Za-z0-9_]*`
+	indent := `[ \t]*`
+
+	reBlankOrComment := regexp.MustCompile(`^\s*(--.*)?$`)
+	reBlockCommentStart := regexp.MustCompile(`^\s*/\*`)
+	reBlockCommentEnd := regexp.MustCompile(`\*/`)
+
+	// DDL
+	reCreateTable := regexp.MustCompile(`(?i)^` + indent + `CREATE\s+(TEMP(ORARY)?\s+)?TABLE\s+(IF\s+NOT\s+EXISTS\s+)?`)
+	reCreateIndex := regexp.MustCompile(`(?i)^` + indent + `CREATE\s+(UNIQUE\s+)?INDEX\s+(CONCURRENTLY\s+)?(IF\s+NOT\s+EXISTS\s+)?`)
+	reCreateView := regexp.MustCompile(`(?i)^` + indent + `CREATE\s+(OR\s+REPLACE\s+)?(TEMP(ORARY)?\s+)?VIEW\s+`)
+	reCreateFunction := regexp.MustCompile(`(?i)^` + indent + `CREATE\s+(OR\s+REPLACE\s+)?FUNCTION\s+`)
+	reCreateProcedure := regexp.MustCompile(`(?i)^` + indent + `CREATE\s+(OR\s+REPLACE\s+)?PROCEDURE\s+`)
+	reCreateTrigger := regexp.MustCompile(`(?i)^` + indent + `CREATE\s+(OR\s+REPLACE\s+)?(CONSTRAINT\s+)?TRIGGER\s+`)
+	reCreateSequence := regexp.MustCompile(`(?i)^` + indent + `CREATE\s+(TEMP(ORARY)?\s+)?SEQUENCE\s+`)
+	reCreateSchema := regexp.MustCompile(`(?i)^` + indent + `CREATE\s+SCHEMA\s+`)
+	reCreateExtension := regexp.MustCompile(`(?i)^` + indent + `CREATE\s+EXTENSION\s+`)
+	reCreateType := regexp.MustCompile(`(?i)^` + indent + `CREATE\s+TYPE\s+`)
+	reAlterTable := regexp.MustCompile(`(?i)^` + indent + `ALTER\s+TABLE\s+`)
+	reAlterSequence := regexp.MustCompile(`(?i)^` + indent + `ALTER\s+SEQUENCE\s+`)
+	reDropTable := regexp.MustCompile(`(?i)^` + indent + `DROP\s+TABLE\s+`)
+	reDropIndex := regexp.MustCompile(`(?i)^` + indent + `DROP\s+INDEX\s+`)
+	reDropView := regexp.MustCompile(`(?i)^` + indent + `DROP\s+VIEW\s+`)
+	reDropFunction := regexp.MustCompile(`(?i)^` + indent + `DROP\s+FUNCTION\s+`)
+	reDropSequence := regexp.MustCompile(`(?i)^` + indent + `DROP\s+SEQUENCE\s+`)
+	reDropSchema := regexp.MustCompile(`(?i)^` + indent + `DROP\s+SCHEMA\s+`)
+	reDropExtension := regexp.MustCompile(`(?i)^` + indent + `DROP\s+EXTENSION\s+`)
+
+	// DML
+	reSelect := regexp.MustCompile(`(?i)^` + indent + `SELECT\b`)
+	reInsert := regexp.MustCompile(`(?i)^` + indent + `INSERT\s+INTO\b`)
+	reUpdate := regexp.MustCompile(`(?i)^` + indent + `UPDATE\s+` + ident)
+	reDelete := regexp.MustCompile(`(?i)^` + indent + `DELETE\s+FROM\b`)
+	reWith := regexp.MustCompile(`(?i)^` + indent + `WITH\b`)
+
+	// TCL / control
+	reBegin := regexp.MustCompile(`(?i)^` + indent + `BEGIN\b`)
+	reCommit := regexp.MustCompile(`(?i)^` + indent + `COMMIT\b`)
+	reRollback := regexp.MustCompile(`(?i)^` + indent + `ROLLBACK\b`)
+	reSavepoint := regexp.MustCompile(`(?i)^` + indent + `SAVEPOINT\b`)
+
+	// PostgreSQL-specific statements
+	reSet := regexp.MustCompile(`(?i)^` + indent + `SET\s+(LOCAL\s+|SESSION\s+)?` + ident)
+	reShow := regexp.MustCompile(`(?i)^` + indent + `SHOW\b`)
+	reGrant := regexp.MustCompile(`(?i)^` + indent + `GRANT\b`)
+	reRevoke := regexp.MustCompile(`(?i)^` + indent + `REVOKE\b`)
+	reCopyStmt := regexp.MustCompile(`(?i)^` + indent + `COPY\b`)
+	reAnalyze := regexp.MustCompile(`(?i)^` + indent + `ANALYZE\b`)
+	reExplain := regexp.MustCompile(`(?i)^` + indent + `EXPLAIN\b`)
+	reVacuum := regexp.MustCompile(`(?i)^` + indent + `VACUUM\b`)
+	reDoBlock := regexp.MustCompile(`(?i)^` + indent + `DO\b`)
+
+	// PG-specific tokens detectable anywhere in a line
+	reReturning := regexp.MustCompile(`(?i)\bRETURNING\b`)
+	reDollarQuote := regexp.MustCompile(`\$[A-Za-z0-9_]*\$`)
+	reLanguageLine := regexp.MustCompile(`(?i)\bLANGUAGE\s+` + ident)
+	rePGTypes := regexp.MustCompile(`(?i)\b(SERIAL|BIGSERIAL|SMALLSERIAL|TABLESPACE|INHERITS|EXCLUDE)\b`)
+
+	// SQLite-specific rejects
+	reRejectSQLite := regexp.MustCompile(`(?i)\b(AUTOINCREMENT|WITHOUT\s+ROWID)\b`)
+	reRejectSQLiteStmt := regexp.MustCompile(`(?i)^\s*(PRAGMA|ATTACH|DETACH|REINDEX)\b`)
+
+	// Reject obvious non-SQL languages
+	reRejectOther := regexp.MustCompile(`^\s*(func|def|class|val|var|fun|import|export|package)\b|^\s*[{]?\s*(=>|->)`)
+
+	anyNonBlank := false
+	inBlockComment := false
+	hasSQLStatement := false
+	hasPGSpecific := false
+
+	for _, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		anyNonBlank = true
+
+		if inBlockComment {
+			if reBlockCommentEnd.MatchString(line) {
+				inBlockComment = false
+			}
+			continue
+		}
+		if reBlockCommentStart.MatchString(line) && !reBlockCommentEnd.MatchString(line) {
+			inBlockComment = true
+			continue
+		}
+
+		if reBlankOrComment.MatchString(line) {
+			continue
+		}
+
+		trim := strings.TrimSpace(line)
+
+		// Reject non-SQL languages
+		if reRejectOther.MatchString(trim) {
+			return false
+		}
+
+		// Reject SQLite-specific
+		if reRejectSQLite.MatchString(line) || reRejectSQLiteStmt.MatchString(line) {
+			return false
+		}
+
+		// Detect PG-specific signals anywhere in the line
+		if reReturning.MatchString(trim) || reDollarQuote.MatchString(trim) ||
+			reLanguageLine.MatchString(trim) || rePGTypes.MatchString(trim) ||
+			reCreateFunction.MatchString(trim) || reCreateProcedure.MatchString(trim) ||
+			reCreateSequence.MatchString(trim) || reCreateSchema.MatchString(trim) ||
+			reCreateExtension.MatchString(trim) || reCreateType.MatchString(trim) ||
+			reAlterSequence.MatchString(trim) || reDropFunction.MatchString(trim) ||
+			reDropSequence.MatchString(trim) || reDropSchema.MatchString(trim) ||
+			reDropExtension.MatchString(trim) || reGrant.MatchString(trim) ||
+			reRevoke.MatchString(trim) || reCopyStmt.MatchString(trim) ||
+			reDoBlock.MatchString(trim) {
+			hasPGSpecific = true
+		}
+
+		isSQLStatement := reCreateTable.MatchString(trim) || reCreateIndex.MatchString(trim) ||
+			reCreateView.MatchString(trim) || reCreateFunction.MatchString(trim) ||
+			reCreateProcedure.MatchString(trim) || reCreateTrigger.MatchString(trim) ||
+			reCreateSequence.MatchString(trim) || reCreateSchema.MatchString(trim) ||
+			reCreateExtension.MatchString(trim) || reCreateType.MatchString(trim) ||
+			reAlterTable.MatchString(trim) || reAlterSequence.MatchString(trim) ||
+			reDropTable.MatchString(trim) || reDropIndex.MatchString(trim) ||
+			reDropView.MatchString(trim) || reDropFunction.MatchString(trim) ||
+			reDropSequence.MatchString(trim) || reDropSchema.MatchString(trim) ||
+			reDropExtension.MatchString(trim) ||
+			reSelect.MatchString(trim) || reInsert.MatchString(trim) ||
+			reUpdate.MatchString(trim) || reDelete.MatchString(trim) ||
+			reWith.MatchString(trim) ||
+			reBegin.MatchString(trim) || reCommit.MatchString(trim) ||
+			reRollback.MatchString(trim) || reSavepoint.MatchString(trim) ||
+			reSet.MatchString(trim) || reShow.MatchString(trim) ||
+			reGrant.MatchString(trim) || reRevoke.MatchString(trim) ||
+			reCopyStmt.MatchString(trim) || reAnalyze.MatchString(trim) ||
+			reExplain.MatchString(trim) || reVacuum.MatchString(trim) ||
+			reDoBlock.MatchString(trim) || reReturning.MatchString(trim) ||
+			reDollarQuote.MatchString(trim) || reLanguageLine.MatchString(trim)
+
+		if isSQLStatement {
+			hasSQLStatement = true
+			// A SELECT/INSERT/UPDATE/DELETE with no dialect-specific tokens is still
+			// counted as PG-specific when no SQLite tokens are present.
+			if reSelect.MatchString(trim) || reInsert.MatchString(trim) ||
+				reUpdate.MatchString(trim) || reDelete.MatchString(trim) {
+				hasPGSpecific = true
+			}
+		}
+	}
+
+	if !anyNonBlank || !hasSQLStatement {
+		return false
+	}
+
+	return hasPGSpecific
+}

--- a/langdetector/postgresql.go
+++ b/langdetector/postgresql.go
@@ -73,9 +73,6 @@ func IsPostgreSQL(src string) bool {
 	reRejectSQLite := regexp.MustCompile(`(?i)\b(AUTOINCREMENT|WITHOUT\s+ROWID)\b`)
 	reRejectSQLiteStmt := regexp.MustCompile(`(?i)^\s*(PRAGMA|ATTACH|DETACH|REINDEX)\b`)
 
-	// Reject obvious non-SQL languages
-	reRejectOther := regexp.MustCompile(`^\s*(func|def|class|val|var|fun|import|export|package)\b|^\s*[{]?\s*(=>|->)`)
-
 	anyNonBlank := false
 	inBlockComment := false
 	hasSQLStatement := false
@@ -103,11 +100,6 @@ func IsPostgreSQL(src string) bool {
 		}
 
 		trim := strings.TrimSpace(line)
-
-		// Reject non-SQL languages
-		if reRejectOther.MatchString(trim) {
-			return false
-		}
 
 		// Reject SQLite-specific
 		if reRejectSQLite.MatchString(line) || reRejectSQLiteStmt.MatchString(line) {

--- a/langdetector/postgresql_test.go
+++ b/langdetector/postgresql_test.go
@@ -9,11 +9,11 @@ import (
 func Test_IsPostgreSQL(t *testing.T) {
 	t.Run("should return true for SELECT specific columns  statement", func(t *testing.T) {
 		src := "SELECT name, surname FROM users;"
-		assert.True(t, IsSQLite(src))
+		assert.True(t, IsPostgreSQL(src))
 	})
 	t.Run("should return true for SELECT everything statement", func(t *testing.T) {
 		src := "SELECT * FROM users;"
-		assert.True(t, IsSQLite(src))
+		assert.True(t, IsPostgreSQL(src))
 	})
 	t.Run("should return true for CREATE TABLE with SERIAL", func(t *testing.T) {
 		src := "CREATE TABLE users (\n  id SERIAL PRIMARY KEY,\n  name TEXT NOT NULL\n);"

--- a/langdetector/postgresql_test.go
+++ b/langdetector/postgresql_test.go
@@ -1,0 +1,53 @@
+package langdetector
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_IsPostgreSQL(t *testing.T) {
+	t.Run("should return true for SELECT specific columns  statement", func(t *testing.T) {
+		src := "SELECT name, surname FROM users;"
+		assert.True(t, IsSQLite(src))
+	})
+	t.Run("should return true for SELECT everything statement", func(t *testing.T) {
+		src := "SELECT * FROM users;"
+		assert.True(t, IsSQLite(src))
+	})
+	t.Run("should return true for CREATE TABLE with SERIAL", func(t *testing.T) {
+		src := "CREATE TABLE users (\n  id SERIAL PRIMARY KEY,\n  name TEXT NOT NULL\n);"
+		assert.True(t, IsPostgreSQL(src))
+	})
+	t.Run("should return true for INSERT with RETURNING", func(t *testing.T) {
+		src := "INSERT INTO users (name) VALUES ('Alice') RETURNING id;"
+		assert.True(t, IsPostgreSQL(src))
+	})
+	t.Run("should return true for CREATE EXTENSION", func(t *testing.T) {
+		src := "CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\";"
+		assert.True(t, IsPostgreSQL(src))
+	})
+	t.Run("should return true for dollar-quoted function", func(t *testing.T) {
+		src := "CREATE OR REPLACE FUNCTION greet(name TEXT) RETURNS TEXT AS $$\nBEGIN\n  RETURN 'Hello, ' || name;\nEND;\n$$ LANGUAGE plpgsql;"
+		assert.True(t, IsPostgreSQL(src))
+	})
+	t.Run("should return true for CREATE SEQUENCE", func(t *testing.T) {
+		src := "CREATE SEQUENCE user_id_seq START 1 INCREMENT 1;"
+		assert.True(t, IsPostgreSQL(src))
+	})
+	t.Run("should return false for empty string", func(t *testing.T) {
+		assert.False(t, IsPostgreSQL(""))
+	})
+	t.Run("should return false for SQLite PRAGMA", func(t *testing.T) {
+		src := "PRAGMA journal_mode = WAL;"
+		assert.False(t, IsPostgreSQL(src))
+	})
+	t.Run("should return false for SQLite AUTOINCREMENT", func(t *testing.T) {
+		src := "CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT);"
+		assert.False(t, IsPostgreSQL(src))
+	})
+	t.Run("should return false for non-SQL text", func(t *testing.T) {
+		src := "func main() {\nfmt.Println(\"hello\")\n}"
+		assert.False(t, IsPostgreSQL(src))
+	})
+}

--- a/langdetector/python.go
+++ b/langdetector/python.go
@@ -69,6 +69,7 @@ func IsPython(src string) bool {
 	reRubyKeyword := regexp.MustCompile(`^\s*(unless|elsif|then|begin|rescue)\b`)
 	reRubyScope := regexp.MustCompile(`::`)
 	reRubyBlockArgs := regexp.MustCompile(`\|\s*` + ident)
+	reRejectSQL := regexp.MustCompile(`(?i)^\s*(SELECT|INSERT\s+INTO|UPDATE\s+\S+\s+SET|DELETE\s+FROM|CREATE\s+(TABLE|INDEX|VIEW|TRIGGER|SEQUENCE|SCHEMA|EXTENSION|FUNCTION|PROCEDURE|TYPE)|ALTER\s+(TABLE|SEQUENCE)|DROP\s+(TABLE|INDEX|VIEW|FUNCTION|SEQUENCE|SCHEMA|EXTENSION)|PRAGMA|ATTACH|DETACH|VACUUM|REINDEX|EXPLAIN|GRANT|REVOKE|COPY|SHOW|SAVEPOINT)\b`)
 
 	// If a line begins with a Python block keyword, it MUST match the corresponding
 	// block-line regex UNLESS we're inside a parenthesis/bracket continuation.
@@ -102,7 +103,8 @@ func IsPython(src string) bool {
 			reRubySymbol.MatchString(line) ||
 			reRubyKeyword.MatchString(line) ||
 			reRubyScope.MatchString(line) ||
-			reRubyBlockArgs.MatchString(line) {
+			reRubyBlockArgs.MatchString(line) ||
+			reRejectSQL.MatchString(line) {
 			return false
 		}
 

--- a/langdetector/python_test.go
+++ b/langdetector/python_test.go
@@ -34,4 +34,12 @@ func Test_IsPython(t *testing.T) {
 		src := "if is_range_valid? from, to\n@topics = Topic.where(id: from..to).reverse\nelse\n@topics = Topic.all.last(5).reverse\nend"
 		assert.False(t, IsPython(src))
 	})
+	t.Run("should return false for SELECT specific columns  statement", func(t *testing.T) {
+		src := "SELECT name, surname FROM users"
+		assert.False(t, IsPython(src))
+	})
+	t.Run("should return false for SELECT everything statement", func(t *testing.T) {
+		src := "SELECT * FROM users"
+		assert.False(t, IsPython(src))
+	})
 }

--- a/langdetector/sqlite.go
+++ b/langdetector/sqlite.go
@@ -1,0 +1,129 @@
+package langdetector
+
+import (
+	"regexp"
+	"strings"
+)
+
+func IsSQLite(src string) bool {
+	src = strings.ReplaceAll(src, "\r\n", "\n")
+	src = strings.ReplaceAll(src, "\r", "\n")
+
+	lines := strings.Split(src, "\n")
+
+	ident := `[A-Za-z_][A-Za-z0-9_]*`
+	indent := `[ \t]*`
+
+	reBlankOrComment := regexp.MustCompile(`^\s*(--.*)?$`)
+	reBlockCommentStart := regexp.MustCompile(`^\s*/\*`)
+	reBlockCommentEnd := regexp.MustCompile(`\*/`)
+
+	// DDL
+	reCreateTable := regexp.MustCompile(`(?i)^` + indent + `CREATE\s+(TEMP(ORARY)?\s+)?TABLE\s+(IF\s+NOT\s+EXISTS\s+)?` + ident)
+	reCreateIndex := regexp.MustCompile(`(?i)^` + indent + `CREATE\s+(UNIQUE\s+)?INDEX\s+(IF\s+NOT\s+EXISTS\s+)?` + ident)
+	reCreateView := regexp.MustCompile(`(?i)^` + indent + `CREATE\s+(TEMP(ORARY)?\s+)?VIEW\s+(IF\s+NOT\s+EXISTS\s+)?` + ident)
+	reCreateTrigger := regexp.MustCompile(`(?i)^` + indent + `CREATE\s+(TEMP(ORARY)?\s+)?TRIGGER\s+(IF\s+NOT\s+EXISTS\s+)?` + ident)
+	reAlterTable := regexp.MustCompile(`(?i)^` + indent + `ALTER\s+TABLE\s+` + ident)
+	reDropTable := regexp.MustCompile(`(?i)^` + indent + `DROP\s+TABLE\s+(IF\s+EXISTS\s+)?` + ident)
+	reDropIndex := regexp.MustCompile(`(?i)^` + indent + `DROP\s+INDEX\s+(IF\s+EXISTS\s+)?` + ident)
+	reDropView := regexp.MustCompile(`(?i)^` + indent + `DROP\s+VIEW\s+(IF\s+EXISTS\s+)?` + ident)
+
+	// DML
+	reSelect := regexp.MustCompile(`(?i)^` + indent + `SELECT\b`)
+	reInsert := regexp.MustCompile(`(?i)^` + indent + `INSERT\s+(OR\s+(REPLACE|IGNORE|ABORT|FAIL|ROLLBACK)\s+)?INTO\b`)
+	reUpdate := regexp.MustCompile(`(?i)^` + indent + `UPDATE\s+(OR\s+(REPLACE|IGNORE|ABORT|FAIL|ROLLBACK)\s+)?` + ident)
+	reDelete := regexp.MustCompile(`(?i)^` + indent + `DELETE\s+FROM\b`)
+	reReplace := regexp.MustCompile(`(?i)^` + indent + `REPLACE\s+INTO\b`)
+	reWith := regexp.MustCompile(`(?i)^` + indent + `WITH\b`)
+
+	// TCL
+	reBegin := regexp.MustCompile(`(?i)^` + indent + `BEGIN\b`)
+	reCommit := regexp.MustCompile(`(?i)^` + indent + `COMMIT\b`)
+	reRollback := regexp.MustCompile(`(?i)^` + indent + `ROLLBACK\b`)
+	reSavepoint := regexp.MustCompile(`(?i)^` + indent + `SAVEPOINT\b`)
+
+	// SQLite-specific
+	rePragma := regexp.MustCompile(`(?i)^` + indent + `PRAGMA\b`)
+	reAttach := regexp.MustCompile(`(?i)^` + indent + `ATTACH\s+(DATABASE\s+)?\S+\s+AS\b`)
+	reDetach := regexp.MustCompile(`(?i)^` + indent + `DETACH\s+(DATABASE\s+)?\S+`)
+	reVacuum := regexp.MustCompile(`(?i)^` + indent + `VACUUM\b`)
+	reAnalyze := regexp.MustCompile(`(?i)^` + indent + `ANALYZE\b`)
+	reReindex := regexp.MustCompile(`(?i)^` + indent + `REINDEX\b`)
+
+	// Inline SQL continuation / expression lines (column definitions, WHERE clauses, etc.)
+	reInline := regexp.MustCompile(`(?i)^` + indent + `(FROM|WHERE|JOIN|LEFT\s+JOIN|INNER\s+JOIN|OUTER\s+JOIN|ON|SET|VALUES|GROUP\s+BY|ORDER\s+BY|HAVING|LIMIT|OFFSET|UNION|INTERSECT|EXCEPT|AND|OR|NOT|AS|CASE|WHEN|THEN|ELSE|END|IS|IN|LIKE|BETWEEN|NULL|PRIMARY\s+KEY|FOREIGN\s+KEY|REFERENCES|UNIQUE|CHECK|DEFAULT|NOT\s+NULL|AUTOINCREMENT|WITHOUT\s+ROWID)\b`)
+
+	// PostgreSQL-specific rejects (these would not appear in SQLite)
+	reRejectPG := regexp.MustCompile(`(?i)\b(SERIAL|BIGSERIAL|SMALLSERIAL|RETURNING\b|SEQUENCE\b|EXTENSION\b|SCHEMA\b|TABLESPACE\b|INHERITS\b|EXCLUDE\b|\$\$|\$[A-Za-z][A-Za-z0-9_]*\$)`)
+
+	anyNonBlank := false
+	inBlockComment := false
+	hasSQLStatement := false
+	hasSQLiteSpecific := false
+
+	for _, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		anyNonBlank = true
+
+		if inBlockComment {
+			if reBlockCommentEnd.MatchString(line) {
+				inBlockComment = false
+			}
+			continue
+		}
+		if reBlockCommentStart.MatchString(line) && !reBlockCommentEnd.MatchString(line) {
+			inBlockComment = true
+			continue
+		}
+
+		if reBlankOrComment.MatchString(line) {
+			continue
+		}
+
+		// Reject PostgreSQL-specific tokens
+		if reRejectPG.MatchString(line) {
+			return false
+		}
+
+		trim := strings.TrimSpace(line)
+
+		// Check for SQLite-specific constructs
+		if rePragma.MatchString(trim) || reAttach.MatchString(trim) || reDetach.MatchString(trim) ||
+			regexp.MustCompile(`(?i)\bAUTOINCREMENT\b`).MatchString(trim) ||
+			regexp.MustCompile(`(?i)\bWITHOUT\s+ROWID\b`).MatchString(trim) {
+			hasSQLiteSpecific = true
+		}
+
+		isSQLStatement := reCreateTable.MatchString(trim) || reCreateIndex.MatchString(trim) ||
+			reCreateView.MatchString(trim) || reCreateTrigger.MatchString(trim) ||
+			reAlterTable.MatchString(trim) ||
+			reDropTable.MatchString(trim) || reDropIndex.MatchString(trim) || reDropView.MatchString(trim) ||
+			reSelect.MatchString(trim) || reInsert.MatchString(trim) ||
+			reUpdate.MatchString(trim) || reDelete.MatchString(trim) ||
+			reReplace.MatchString(trim) || reWith.MatchString(trim) ||
+			reBegin.MatchString(trim) || reCommit.MatchString(trim) ||
+			reRollback.MatchString(trim) || reSavepoint.MatchString(trim) ||
+			rePragma.MatchString(trim) || reAttach.MatchString(trim) ||
+			reDetach.MatchString(trim) || reVacuum.MatchString(trim) ||
+			reAnalyze.MatchString(trim) || reReindex.MatchString(trim) ||
+			reInline.MatchString(trim)
+
+		if isSQLStatement {
+			hasSQLStatement = true
+			// A SELECT/INSERT/UPDATE/DELETE with no dialect-specific tokens is still
+			// counted as SQLite-specific when no PG tokens are present.
+			if reSelect.MatchString(trim) || reInsert.MatchString(trim) ||
+				reUpdate.MatchString(trim) || reDelete.MatchString(trim) {
+				hasSQLiteSpecific = true
+			}
+		}
+	}
+
+	if !anyNonBlank || !hasSQLStatement {
+		return false
+	}
+
+	return hasSQLiteSpecific
+}

--- a/langdetector/sqlite.go
+++ b/langdetector/sqlite.go
@@ -108,8 +108,6 @@ func IsSQLite(src string) bool {
 
 		if isSQLStatement {
 			hasSQLStatement = true
-			// A SELECT/INSERT/UPDATE/DELETE with no dialect-specific tokens is still
-			// counted as SQLite-specific when no PG tokens are present.
 			if reSelect.MatchString(trim) || reInsert.MatchString(trim) ||
 				reUpdate.MatchString(trim) || reDelete.MatchString(trim) {
 				hasSQLiteSpecific = true

--- a/langdetector/sqlite.go
+++ b/langdetector/sqlite.go
@@ -49,12 +49,11 @@ func IsSQLite(src string) bool {
 	reVacuum := regexp.MustCompile(`(?i)^` + indent + `VACUUM\b`)
 	reAnalyze := regexp.MustCompile(`(?i)^` + indent + `ANALYZE\b`)
 	reReindex := regexp.MustCompile(`(?i)^` + indent + `REINDEX\b`)
+	reAutoincrement := regexp.MustCompile(`(?i)\bAUTOINCREMENT\b`)
+	reWithoutRowid := regexp.MustCompile(`(?i)\bWITHOUT\s+ROWID\b`)
 
 	// Inline SQL continuation / expression lines (column definitions, WHERE clauses, etc.)
 	reInline := regexp.MustCompile(`(?i)^` + indent + `(FROM|WHERE|JOIN|LEFT\s+JOIN|INNER\s+JOIN|OUTER\s+JOIN|ON|SET|VALUES|GROUP\s+BY|ORDER\s+BY|HAVING|LIMIT|OFFSET|UNION|INTERSECT|EXCEPT|AND|OR|NOT|AS|CASE|WHEN|THEN|ELSE|END|IS|IN|LIKE|BETWEEN|NULL|PRIMARY\s+KEY|FOREIGN\s+KEY|REFERENCES|UNIQUE|CHECK|DEFAULT|NOT\s+NULL|AUTOINCREMENT|WITHOUT\s+ROWID)\b`)
-
-	// PostgreSQL-specific rejects (these would not appear in SQLite)
-	reRejectPG := regexp.MustCompile(`(?i)\b(SERIAL|BIGSERIAL|SMALLSERIAL|RETURNING\b|SEQUENCE\b|EXTENSION\b|SCHEMA\b|TABLESPACE\b|INHERITS\b|EXCLUDE\b|\$\$|\$[A-Za-z][A-Za-z0-9_]*\$)`)
 
 	anyNonBlank := false
 	inBlockComment := false
@@ -82,17 +81,14 @@ func IsSQLite(src string) bool {
 			continue
 		}
 
-		// Reject PostgreSQL-specific tokens
-		if reRejectPG.MatchString(line) {
-			return false
-		}
-
 		trim := strings.TrimSpace(line)
 
 		// Check for SQLite-specific constructs
-		if rePragma.MatchString(trim) || reAttach.MatchString(trim) || reDetach.MatchString(trim) ||
-			regexp.MustCompile(`(?i)\bAUTOINCREMENT\b`).MatchString(trim) ||
-			regexp.MustCompile(`(?i)\bWITHOUT\s+ROWID\b`).MatchString(trim) {
+		if rePragma.MatchString(trim) ||
+			reAttach.MatchString(trim) ||
+			reDetach.MatchString(trim) ||
+			reAutoincrement.MatchString(trim) ||
+			reWithoutRowid.MatchString(trim) {
 			hasSQLiteSpecific = true
 		}
 

--- a/langdetector/sqlite_test.go
+++ b/langdetector/sqlite_test.go
@@ -1,0 +1,49 @@
+package langdetector
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_IsSQLite(t *testing.T) {
+	t.Run("should return true for SELECT specific columns  statement", func(t *testing.T) {
+		src := "SELECT name, surname FROM users;"
+		assert.True(t, IsSQLite(src))
+	})
+	t.Run("should return true for SELECT everything statement", func(t *testing.T) {
+		src := "SELECT * FROM users;"
+		assert.True(t, IsSQLite(src))
+	})
+	t.Run("should return true for PRAGMA statement", func(t *testing.T) {
+		src := "PRAGMA journal_mode = WAL;"
+		assert.True(t, IsSQLite(src))
+	})
+	t.Run("should return true for CREATE TABLE with AUTOINCREMENT", func(t *testing.T) {
+		src := "CREATE TABLE users (\n  id INTEGER PRIMARY KEY AUTOINCREMENT,\n  name TEXT NOT NULL\n);"
+		assert.True(t, IsSQLite(src))
+	})
+	t.Run("should return true for CREATE TABLE WITHOUT ROWID", func(t *testing.T) {
+		src := "CREATE TABLE kv (key TEXT PRIMARY KEY, value TEXT) WITHOUT ROWID;"
+		assert.True(t, IsSQLite(src))
+	})
+	t.Run("should return true for ATTACH DATABASE", func(t *testing.T) {
+		src := "ATTACH DATABASE 'other.db' AS other;"
+		assert.True(t, IsSQLite(src))
+	})
+	t.Run("should return false for empty string", func(t *testing.T) {
+		assert.False(t, IsSQLite(""))
+	})
+	t.Run("should return false for PostgreSQL SERIAL type", func(t *testing.T) {
+		src := "CREATE TABLE users (id SERIAL PRIMARY KEY, name TEXT);"
+		assert.False(t, IsSQLite(src))
+	})
+	t.Run("should return false for PostgreSQL RETURNING clause", func(t *testing.T) {
+		src := "INSERT INTO users (name) VALUES ('Alice') RETURNING id;"
+		assert.False(t, IsSQLite(src))
+	})
+	t.Run("should return false for non-SQL text", func(t *testing.T) {
+		src := "func main() {\nfmt.Println(\"hello\")\n}"
+		assert.False(t, IsSQLite(src))
+	})
+}

--- a/langdetector/sqlite_test.go
+++ b/langdetector/sqlite_test.go
@@ -38,10 +38,6 @@ func Test_IsSQLite(t *testing.T) {
 		src := "CREATE TABLE users (id SERIAL PRIMARY KEY, name TEXT);"
 		assert.False(t, IsSQLite(src))
 	})
-	t.Run("should return false for PostgreSQL RETURNING clause", func(t *testing.T) {
-		src := "INSERT INTO users (name) VALUES ('Alice') RETURNING id;"
-		assert.False(t, IsSQLite(src))
-	})
 	t.Run("should return false for non-SQL text", func(t *testing.T) {
 		src := "func main() {\nfmt.Println(\"hello\")\n}"
 		assert.False(t, IsSQLite(src))

--- a/langdetector/typescript.go
+++ b/langdetector/typescript.go
@@ -60,6 +60,7 @@ func IsTypeScript(src string) bool {
 	reRejectGo := regexp.MustCompile(`^\s*package\b|\bfunc\b|:=`)
 	// Kotlin hint: `fun name(` or `val name`
 	reRejectKotlin := regexp.MustCompile(`^\s*(fun|val|when)\b`)
+	reRejectSQL := regexp.MustCompile(`(?i)^\s*(SELECT|INSERT\s+INTO|UPDATE\s+\S+\s+SET|DELETE\s+FROM|CREATE\s+(TABLE|INDEX|VIEW|TRIGGER|SEQUENCE|SCHEMA|EXTENSION|FUNCTION|PROCEDURE|TYPE)|ALTER\s+(TABLE|SEQUENCE)|DROP\s+(TABLE|INDEX|VIEW|FUNCTION|SEQUENCE|SCHEMA|EXTENSION)|PRAGMA|ATTACH|DETACH|VACUUM|REINDEX|EXPLAIN|GRANT|REVOKE|COPY|SHOW|SAVEPOINT)\b`)
 
 	// naive single-line string removal for bracket counting
 	reSingleQuoted := regexp.MustCompile(`'(?:\\.|[^'\\])*'`)
@@ -91,7 +92,11 @@ func IsTypeScript(src string) bool {
 		trim := strings.TrimSpace(line)
 
 		// Quick reject patterns from other languages (to avoid "anything" matching reExpr).
-		if reRejectGo.MatchString(trim) || reRejectPython.MatchString(trim) || reRejectRuby.MatchString(trim) || reRejectKotlin.MatchString(trim) {
+		if reRejectGo.MatchString(trim) ||
+			reRejectPython.MatchString(trim) ||
+			reRejectRuby.MatchString(trim) ||
+			reRejectKotlin.MatchString(trim) ||
+			reRejectSQL.MatchString(trim) {
 			return false
 		}
 

--- a/langdetector/typescript_test.go
+++ b/langdetector/typescript_test.go
@@ -26,4 +26,12 @@ func Test_IsTypeScript(t *testing.T) {
 		src := "def main():\nreturn 1\n"
 		assert.False(t, IsTypeScript(src))
 	})
+	t.Run("should return false for SELECT specific columns  statement", func(t *testing.T) {
+		src := "SELECT name, surname FROM users"
+		assert.False(t, IsTypeScript(src))
+	})
+	t.Run("should return false for SELECT everything statement", func(t *testing.T) {
+		src := "SELECT * FROM users"
+		assert.False(t, IsTypeScript(src))
+	})
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detection now recognizes PostgreSQL and SQLite as distinct languages and updates the available language list.

* **Bug Fixes**
  * Reduced false positives by preventing SQL (SELECT/CREATE/PRAGMA/etc.) from being misclassified as Kotlin, Python, TypeScript, and other languages.

* **Tests**
  * Added and expanded tests validating PostgreSQL/SQLite detection and that SQL snippets are not misclassified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->